### PR TITLE
Remove unused .testinfo.tmt file

### DIFF
--- a/Security/large-metadata/.testinfo.tmt
+++ b/Security/large-metadata/.testinfo.tmt
@@ -1,7 +1,0 @@
-Description: Test storing LARGE metadata to LUKS1 device
-Owner: Sergio Correia <scorreia@redhat.com>
-RunFor: luksmeta
-RunTest: ./test.sh
-Path: /mnt/tests/Security/large-metadata
-Requires: luksmeta cryptsetup util-linux util-linux-core xfsprogs
-TestTime: 5m


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the obsolete Security/large-metadata/.testinfo.tmt file that is no longer used.