### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error/main.fmf
+++ b/Regression/bz1461448-running-luksmeta-on-a-non-LUKS-device-returns-IO-error/main.fmf
@@ -1,5 +1,8 @@
 summary: runs luksmeta on a non-LUKS block device
-description: ''
+description: |
+    Verify that luksmeta returns a proper error message when run against a
+    non-LUKS block device, exiting with code 74 and reporting "Unable to read
+    LUKSv1 header" instead of an I/O error.
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Security/large-metadata/main.fmf
+++ b/Security/large-metadata/main.fmf
@@ -1,4 +1,8 @@
 summary: Test storing LARGE metadata to LUKS1 device
+description: |
+    Verify that luksmeta correctly rejects storing metadata that exceeds the
+    LUKS1 header capacity and that the existing LUKS device data remains intact
+    after the failed operation.
 contact: Sergio Correia <scorreia@redhat.com>
 component:
   - luksmeta


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Documentation:
- Document previously undocumented tests by adding descriptions in main.fmf for regression and security test cases.